### PR TITLE
Fix po to output failure due to missing logger variable

### DIFF
--- a/RimTranslate.py
+++ b/RimTranslate.py
@@ -361,7 +361,6 @@ if args.output_dir:
                     if not (os.path.exists(directory)):
                         logging.info("Creating directory " + directory)
                         os.makedirs(directory)
-                    logging.info("Creating XML file for " + pofilename)
                     xml_content = create_languagedata_xml_file(full_filename)
                     target = open(xml_filename, "w", encoding="utf8")
                     target.write(xml_content)


### PR DESCRIPTION
When creating output files from po files, the process fails on a `logging.info` line that's missing its `pofilename` variable.

I've removed it for now just to get the process working.